### PR TITLE
build: find includes from pkgconfig

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -3,23 +3,34 @@ use std::path::PathBuf;
 
 fn main() {
     // Use pkg-config to find the urcrypt library.
-    let _urcrypt = pkg_config::Config::new().atleast_version("0.1.0").probe("liburcrypt-0").unwrap();
+    let urcrypt = pkg_config::Config::new().atleast_version("0.1.0").probe("liburcrypt-0").unwrap();
 
-    for path in _urcrypt.link_paths.iter() {
+
+    for path in urcrypt.link_paths.iter() {
         println!("cargo:rustc-link-search={}", path.display());
+
+        eprintln!("cargo:rustc-link-search={}", path.display());
     }
 
-    for path in _urcrypt.libs.iter() {
+    for path in urcrypt.libs.iter() {
         println!("cargo:rustc-link-lib={}", path);
+        eprintln!("cargo:rustc-link-lib={}", path);
     }
 
     // Tell cargo to invalidate the built crate whenever the wrapper changes.
     println!("cargo:rerun-if-changed=wrapper.h");
 
+    let mut builder = bindgen::Builder::default();
+
+    // Tell bindgen where to find the include file
+    for path in urcrypt.include_paths.iter() {
+        builder = builder.clang_arg(format!("-I{}", path.display()));
+    }
+
     // The bindgen::Builder is the main entry point
     // to bindgen, and lets you build up options for
     // the resulting bindings.
-    let bindings = bindgen::Builder::default()
+    let bindings = builder
         // The input header we would like to generate
         // bindings for.
         .header("wrapper.h")


### PR DESCRIPTION
@matthew-levan please merge and push a new version to cargo

This fixes build.rs to find urcrypt.h via pkgconfig and not assume it is on the system include path